### PR TITLE
Adapt FoundationDB integration tests to utilize Docker

### DIFF
--- a/foundationdb/datadog_checks/foundationdb/check.py
+++ b/foundationdb/datadog_checks/foundationdb/check.py
@@ -13,9 +13,12 @@ from datadog_checks.base.utils.subprocess_output import get_subprocess_output, S
 class FoundationdbCheck(AgentCheck):
     def __init__(self, name, init_config, instances):
         super(FoundationdbCheck, self).__init__(name, init_config, instances)
+        self.fdb_status = init_config.get('fdbstatus_path')
 
     def fdb_status_data(self):
-        return get_subprocess_output(['fdbcli', '--exec', 'status json'], self.log)
+        fdb_args = self.fdb_status[:] # do a copy not to pollute original list
+        fdb_args.append('status json')
+        return get_subprocess_output(fdb_args, self.log)
 
         # If the check is going to perform SQL queries you should define a query manager here.
         # More info at

--- a/foundationdb/tests/common.py
+++ b/foundationdb/tests/common.py
@@ -1,0 +1,1 @@
+E2E_INIT_CONFIG = {'fdbstatus_path': ['docker', 'exec', 'fdb-0', 'fdbcli', '--exec']}

--- a/foundationdb/tests/conftest.py
+++ b/foundationdb/tests/conftest.py
@@ -1,12 +1,38 @@
 
+import json
+import time
+import os
 import pytest
 
+from datadog_checks.dev import WaitFor, docker_run, run_command
+
+from .common import E2E_INIT_CONFIG
+
+INSTANCE = {'use_sudo': False}
+CONFIG = {'init_config': E2E_INIT_CONFIG, 'instances': [INSTANCE]}
+HERE = os.path.dirname(os.path.abspath(__file__))
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    yield
-
+    compose_file = os.path.join(HERE, 'docker', 'docker-compose.yaml')
+    with docker_run(compose_file=compose_file, conditions=[WaitFor(create_database)]):
+        yield CONFIG
 
 @pytest.fixture
 def instance():
-    return {}
+    return INSTANCE
+
+def create_database():
+    base_status = run_command('docker exec fdb-0 fdbcli --exec "status json"', capture=True, check=True)
+    status = json.loads(base_status.stdout)
+    if not status.get('client').get('database_status').get('available'):
+        run_command('docker exec fdb-0 fdbcli --exec "configure new single memory"', capture=True, check=True)
+    i = 0
+    is_healthy = False
+    # Wait for 1 minute for the database to become available for testing
+    while i < 60 and not is_healthy:
+        time.sleep(1)
+        base_status = run_command('docker exec fdb-0 fdbcli --exec "status json"', capture=True, check=True)
+        status = json.loads(base_status.stdout)
+        is_healthy = status.get('cluster').get('data').get('state').get('name') == 'healthy'
+        i += 1

--- a/foundationdb/tests/docker/docker-compose.yaml
+++ b/foundationdb/tests/docker/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  fdb-coordinator:
+    image: foundationdb/foundationdb:6.3.13
+    environment:
+      FDB_COORDINATOR: fdb-coordinator
+      FDB_NETWORKING_MODE: container
+      FDB_COORDINATOR_PORT: 4500
+    ports:
+      - 4500:4500/tcp
+  fdb-server-1:
+    container_name: fdb-0
+    depends_on:
+      - fdb-coordinator
+    image: foundationdb/foundationdb:6.3.13
+    environment:
+      FDB_COORDINATOR: fdb-coordinator
+      FDB_NETWORKING_MODE: container
+      FDB_COORDINATOR_PORT: 4500
+  fdb-server-2:
+    container_name: fdb-1
+    depends_on:
+      - fdb-coordinator
+    image: foundationdb/foundationdb:6.3.13
+    environment:
+      FDB_COORDINATOR: fdb-coordinator
+      FDB_NETWORKING_MODE: container
+      FDB_COORDINATOR_PORT: 4500

--- a/foundationdb/tests/test_foundationdb.py
+++ b/foundationdb/tests/test_foundationdb.py
@@ -3,10 +3,14 @@ import os
 import json
 from typing import Any, Dict
 
+import pytest
+
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.base import AgentCheck
 from datadog_checks.foundationdb import FoundationdbCheck
+
+from .common import E2E_INIT_CONFIG
 
 METRICS = [
     "foundationdb.latency_probe.batch_priority_transaction_start_seconds",
@@ -55,17 +59,20 @@ METRICS = [
 ]
 
 current_dir = dir_path = os.path.dirname(os.path.realpath(__file__)) + '/'
+
+@pytest.mark.usefixtures("dd_environment")
 def test_partial(aggregator, instance):
     with open(current_dir + 'partial.json', 'r') as f:
         data = json.loads(f.read())
-        check = FoundationdbCheck('foundationdb', {}, [instance])
+        check = FoundationdbCheck('foundationdb', E2E_INIT_CONFIG, [instance])
         check.check(instance)
         aggregator.assert_service_check("foundationdb.can_connect", AgentCheck.OK)
 
+@pytest.mark.usefixtures("dd_environment")
 def test_full(aggregator, instance):
     with open(current_dir + 'full.json', 'r') as f:
         data = json.loads(f.read())
-        check = FoundationdbCheck('foundationdb', {}, [instance])
+        check = FoundationdbCheck('foundationdb', E2E_INIT_CONFIG, [instance])
         check.check_metrics(data)
 
         for metric in METRICS:
@@ -74,10 +81,10 @@ def test_full(aggregator, instance):
         aggregator.assert_metrics_using_metadata(get_metadata_metrics())
         aggregator.assert_service_check("foundationdb.can_connect", AgentCheck.OK)
 
-
+@pytest.mark.usefixtures("dd_environment")
 def test_integ(aggregator, instance):
     # type: (AggregatorStub, Dict[str, Any]) -> None
-    check = FoundationdbCheck('foundationdb', {}, [instance])
+    check = FoundationdbCheck('foundationdb', E2E_INIT_CONFIG, [instance])
     check.check(instance)
 
     for metric in METRICS:


### PR DESCRIPTION
This commit makes the test suite run integration tests
by sending queries to a FoundationDB instance running in Docker containers.

The Docker setup is described in the docker-compose.yaml file and
consists of a single coordinator and two DB nodes of version 6.3.13.